### PR TITLE
snapcraft: update to noble build, switch build system to meson

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: modem-manager
-version: 1.20.0-3-dev
+version: 1.23.4-0ubuntu2
 summary: ModemManager is a service which controls mobile broadband
 description: |
   ModemManager is a DBus-activated daemon which controls mobile broadband
@@ -8,10 +8,10 @@ description: |
   power supplies, ModemManager is able to prepare and configure the modems and
   setup connections with them.
   Please find the source code at
-  https://code.launchpad.net/~snappy-hwe-team/snappy-hwe-snaps/+git/modem-manager/+ref/snap-22
+  https://code.launchpad.net/~snappy-hwe-team/snappy-hwe-snaps/+git/modem-manager/+ref/snap-24
 confinement: strict
 grade: stable
-base: core22
+base: core24
 
 slots:
   service: modem-manager
@@ -101,27 +101,27 @@ parts:
       - usr/share/doc/libmm-glib0
 
   modemmanager:
-    plugin: autotools
+    plugin: meson
     after: [ stack-snaps-tools ]
 
     source: https://git.launchpad.net/ubuntu/+source/modemmanager
     source-type: git
-    source-branch: applied/ubuntu/jammy-updates
+    source-branch: applied/ubuntu/noble
 
-    autotools-configure-parameters:
+    meson-parameters:
       - --prefix=/usr
       - --libdir=/usr/lib
       - --libexecdir=/usr/lib/ModemManager
       - --sysconfdir=/etc
-      - --enable-gtk-doc=no
-      - --with-polkit=no
-      - --enable-vala=no
-      - --disable-maintainer-mode
-      # Set explicitly CFLAGS until lp: #1791946 is solved
-      - CFLAGS='-O2 -Wl,-z,relro,-z,now -pie -fpie'
+      - -Dgtk_doc=false
+      - -Dpolkit=no
+      - -Dvapi=false
+    
+    build-environment:
+      - CFLAGS: "-O2 -Wl,-z,relro,-z,now"
 
     build-packages:
-      - autoconf-archive
+      - meson
       - intltool
       - gtk-doc-tools
       - libdbus-glib-1-dev
@@ -160,9 +160,11 @@ parts:
       - libmbim-proxy
       - libmbim-utils
       - libgudev-1.0-0
+      - libqrtr-glib0
 
     override-build: |
       set -ex
+      cd "$CRAFT_PART_SRC"
       "$CRAFT_STAGE"/build-tools/check-versions modemmanager
       # Apply snap related patches
       git config user.email "snapcraft@canonical.com"
@@ -170,10 +172,10 @@ parts:
       git am "$CRAFT_PROJECT_DIR"/patch/*.patch
       # Build (rename .git so configure sets release flag)
       mv .git git
+      cd "$CRAFT_PART_BUILD"
       craftctl default
       # Run all tests ModemManager ships by default
-      make check
-      mv git .git
+      ninja test
       # Strip binaries
       find "$CRAFT_PART_INSTALL"/ -executable -type f | xargs file -Ni |
           grep 'application/x-.*executable\|application/x-.*sharedlib' | cut -d: -f1 | xargs strip
@@ -186,6 +188,7 @@ parts:
       - usr/lib/libmm-glib.so*
       - usr/share/doc/libgudev-1.0-0
       - usr/lib/*/libmbim-glib.so*
+      - usr/lib/*/libqrtr-glib.so*
       - usr/bin/mbimcli
       - usr/bin/mbim-network
       - usr/share/doc/libmbim-glib4

--- a/spread.yaml
+++ b/spread.yaml
@@ -44,17 +44,17 @@ backends:
     plan: n2-standard-2
     halt-timeout: 2h
     systems:
-      - ubuntu-core-22-64:
-          image: ubuntu-22.04-64
+      - ubuntu-core-24-64:
+          image: ubuntu-24.04-64
           workers: 8
           storage: 20G
     prepare: |
-      # Builds UC image on top of classic 22.04
+      # Builds UC image on top of classic 24.04
       "$TESTSLIB"/prepare-restore.sh --prepare-suite
   qemu:
     memory: 4G
     systems:
-      - ubuntu-core-22:
+      - ubuntu-core-24:
           # TODO how is this done in snapd spread?
           #bios: /usr/share/OVMF/OVMF_CODE.fd
           username: test
@@ -67,6 +67,11 @@ exclude:
   - .git
 
 prepare: |
+  # When running this through other means than GH actions, ensure that
+  # the repo is checked out
+  if ! [ -d /home/modem-manager/cicd ]; then
+    git clone https://github.com/snapcore/system-snaps-cicd-tools.git /home/modem-manager/cicd
+  fi
   # Take the MATCH and REBOOT functions from spread and allow our shell
   # scripts to use them as shell commands. The replacements are real
   # executables in cicd/snapd-lib/bin (which is on PATH) but they source
@@ -85,7 +90,7 @@ prepare: |
   "$SYSTEMSNAPSTESTLIB"/prepare.sh
 
 prepare-each: |
-  "$SYSTEMSNAPSTESTLIB"/prepare-each.sh "$SNAP_NAME" 22/stable
+  "$SYSTEMSNAPSTESTLIB"/prepare-each.sh "$SNAP_NAME" 24/stable
 
 restore-each: |
   "$SYSTEMSNAPSTESTLIB"/restore-each.sh


### PR DESCRIPTION
I somewhat updated the manifests included, but I don't remember if it's actually neccessary.

Anyway updates are:
Switch to core24 base
Switch to noble archive for modemmanager
Change build system to meson
Stage libqrtr-glib0 now required