### PR TITLE
Begin core26 development

### DIFF
--- a/patch/0001-Ensure-we-do-not-get-duplicated-traces-on-journal.patch
+++ b/patch/0001-Ensure-we-do-not-get-duplicated-traces-on-journal.patch
@@ -16,7 +16,7 @@ diff --git a/src/mm-log.c b/src/mm-log.c
 index 26260b7..080f957 100644
 --- a/src/mm-log.c
 +++ b/src/mm-log.c
-@@ -339,7 +339,7 @@ mm_log_setup (const gchar  *level,
+@@ -363,7 +363,7 @@ mm_log_setup (const gchar  *level,
      } else
  #endif
      if (!log_file) {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -19,7 +19,7 @@ set -ex
 snap_name=modem-manager
 cicd_path=cicd
 if [ $# -eq 0 ]
-then set -- google:
+then set -- openstack-dev
 fi
 
 num_snaps=0

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: modem-manager
-version: 1.25.95-1ubuntu1
+version: 1.25.95-1-dev
 summary: ModemManager is a service which controls mobile broadband
 description: |
   ModemManager is a DBus-activated daemon which controls mobile broadband
@@ -156,7 +156,6 @@ parts:
       - libmbim-glib-dev
       # Core26
       - bash-completion
-      - udev
       - systemd-dev
 
     stage-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: modem-manager
-version: 1.23.4-3-dev
+version: 1.24.2-0ubuntu1 # Launchpad repo version, not final?
 summary: ModemManager is a service which controls mobile broadband
 description: |
   ModemManager is a DBus-activated daemon which controls mobile broadband
@@ -8,10 +8,11 @@ description: |
   power supplies, ModemManager is able to prepare and configure the modems and
   setup connections with them.
   Please find the source code at
-  https://github.com/snapcore/modem-manager-snap/tree/snap-24
+  https://github.com/snapcore/modem-manager-snap/tree/snap-26
 confinement: strict
-grade: stable
-base: core24
+grade: devel
+base: core26
+build-base: devel
 
 slots:
   service: modem-manager
@@ -106,7 +107,7 @@ parts:
 
     source: https://git.launchpad.net/ubuntu/+source/modemmanager
     source-type: git
-    source-branch: applied/ubuntu/noble
+    source-branch: applied/ubuntu/resolute
 
     meson-parameters:
       - --prefix=/usr
@@ -117,7 +118,7 @@ parts:
       - -Dgtk_doc=false
       - -Dpolkit=no
       - -Dvapi=false
-    
+
     build-environment:
       - CFLAGS: "-O2 -Wl,-z,relro,-z,now"
 
@@ -152,6 +153,10 @@ parts:
       - python3-gi
       - libqmi-glib-dev
       - libmbim-glib-dev
+      # Core26
+      - bash-completion
+      - udev
+      - systemd-dev
 
     stage-packages:
       - libqmi-glib5
@@ -166,7 +171,8 @@ parts:
     override-build: |
       set -ex
       cd "$CRAFT_PART_SRC"
-      "$CRAFT_STAGE"/build-tools/check-versions modemmanager
+      # TODO uncomment this, failing until git repo and deb package are synced with each other
+      #"$CRAFT_STAGE"/build-tools/check-versions modemmanager
       # Apply snap related patches
       git config user.email "snapcraft@canonical.com"
       git config user.name "snapcraft"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: modem-manager
-version: 1.24.2-0ubuntu1 # Launchpad repo version, not final?
+version: 1.25.95-1ubuntu1
 summary: ModemManager is a service which controls mobile broadband
 description: |
   ModemManager is a DBus-activated daemon which controls mobile broadband
@@ -107,7 +107,8 @@ parts:
 
     source: https://git.launchpad.net/ubuntu/+source/modemmanager
     source-type: git
-    source-branch: applied/ubuntu/resolute
+    # TODO: change to applied/ubuntu/resolute once LP branch points to version 1.25.95-1
+    source-branch: ubuntu/resolute-proposed
 
     meson-parameters:
       - --prefix=/usr

--- a/spread.yaml
+++ b/spread.yaml
@@ -68,10 +68,11 @@ backends:
 
   qemu:
     memory: 4G
+    environment:
+      DEFAULT_NETPLAN_FILE: 00-snapd-config.yaml
     systems:
-      - ubuntu-core-24:
-          # TODO how is this done in snapd spread?
-          #bios: /usr/share/OVMF/OVMF_CODE.fd
+      - ubuntu-core-26:
+          bios: uefi
           username: test
           password: test
 
@@ -105,8 +106,10 @@ prepare: |
   "$SYSTEMSNAPSTESTLIB"/prepare.sh
 
 prepare-each: |
-  # OBS: This is temporary to bootstrap
-  snap install --dangerous "$PROJECT_PATH"/"$name"*_amd64.snap
+  # OBS: This is temporary to bootstrap. Remove once the snap is published to stable
+  # and leave only the prepare-each.sh sommand
+  snap install --dangerous "$PROJECT_PATH"/"$SNAP_NAME"*_amd64.snap
+  snap connect modem-manager:mmcli modem-manager:service
   # Run prepare-each step which is a bit of a no-op now
   "$SYSTEMSNAPSTESTLIB"/prepare-each.sh "$SNAP_NAME" 26/stable
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -38,19 +38,34 @@ environment:
   DEFAULT_NETPLAN_FILE: 50-cloud-init.yaml
 
 backends:
-  google:
-    key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-    location: snapd-spread/us-east1-b
-    plan: n2-standard-2
+  openstack-dev:
+    type: openstack
+    key: '$(HOST: echo "$OS_CREDENTIALS_STG_AMD64_PS7")'
+    plan: shared.xsmall
     halt-timeout: 2h
+    wait-timeout: 10m
+    groups: [default]
+    proxy: ingress-haproxy.ps7.canonical.com
+    cidr-port-rel: [10.151.54.0/24:4000]
+    volume-auto-delete: true
+    environment:
+      SNAPD_USE_PROXY: 'true'
+      HTTP_PROXY: 'http://egress.ps7.internal:3128'
+      HTTPS_PROXY: 'http://egress.ps7.internal:3128'
+      http_proxy: 'http://egress.ps7.internal:3128'
+      https_proxy: 'http://egress.ps7.internal:3128'
+      no_proxy: '127.0.0.1,127.0.0.53,localhost'
+      NO_PROXY: '127.0.0.1,127.0.0.53,localhost'
+      NTP_SERVER: 'ntp.ps7.internal'
     systems:
-      - ubuntu-core-24-64:
-          image: ubuntu-24.04-64
+      - ubuntu-core-26-64:
+          image: ubuntu-26.04-64
           workers: 8
           storage: 20G
     prepare: |
-      # Builds UC image on top of classic 24.04
+      # Builds UC image on top of classic 26.04
       "$TESTSLIB"/prepare-restore.sh --prepare-suite
+
   qemu:
     memory: 4G
     systems:
@@ -90,7 +105,10 @@ prepare: |
   "$SYSTEMSNAPSTESTLIB"/prepare.sh
 
 prepare-each: |
-  "$SYSTEMSNAPSTESTLIB"/prepare-each.sh "$SNAP_NAME" 24/stable
+  # OBS: This is temporary to bootstrap
+  snap install --dangerous "$PROJECT_PATH"/"$name"*_amd64.snap
+  # Run prepare-each step which is a bit of a no-op now
+  "$SYSTEMSNAPSTESTLIB"/prepare-each.sh "$SNAP_NAME" 26/stable
 
 restore-each: |
   "$SYSTEMSNAPSTESTLIB"/restore-each.sh


### PR DESCRIPTION
This PR marks the beginning of development for the `modem-manager` snap's `26` channel.

As of now, the notable changes are:
 - changing the base of the snap to `core26` (and `build-base` to `devel` for the time being)
 - changing the source branch to resolute
 - adding three packages `bash-completion`, `udev` and `systemd-dev` to the `build-packages` for the `modemmanager` part
 - changing the line number in the only patch to reflect changes between versions of modemmanager
 - disabling version checking as it fails due to the git and deb versions being different (`1.24.2-0ubuntu1` and `1.24.2-2fakesync1` respectively)

The snap appears to be functional when built for amd64 and installed, but it was not tested properly.