### PR TITLE
patch: add support for Telit Cinterion TX62-W-C

### DIFF
--- a/patch/0002-modem-helpers-cinterion-allow-spaces-in-SXRAT-test-r.patch
+++ b/patch/0002-modem-helpers-cinterion-allow-spaces-in-SXRAT-test-r.patch
@@ -1,0 +1,35 @@
+From 6b6997362b5530708725c16c80ef36cd21609f20 Mon Sep 17 00:00:00 2001
+From: Lorenzo Medici <lorenzo.medici@canonical.com>
+Date: Tue, 24 Mar 2026 09:32:39 +0200
+Subject: [PATCH 1/1] modem-helpers-cinterion: allow spaces in ^SXRAT test
+ response
+
+^SXRAT: (0-6), (0,2,3), (0,2,3)
+
+Fixes: https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/issues/974
+
+Backports 6b6997362b5530708725c16c80ef36cd21609f20 first released in 1.25.1 by
+Author: Dan Williams <dan@ioncontrol.co>
+Date:   Sun Apr 13 19:56:56 2025 -0500
+
+Signed-off-by: Lorenzo Medici <lorenzo.medici@canonical.com>
+---
+ src/plugins/cinterion/mm-modem-helpers-cinterion.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/plugins/cinterion/mm-modem-helpers-cinterion.c b/src/plugins/cinterion/mm-modem-helpers-cinterion.c
+index 7c16fc4f..a9912c4a 100644
+--- a/src/plugins/cinterion/mm-modem-helpers-cinterion.c
++++ b/src/plugins/cinterion/mm-modem-helpers-cinterion.c
+@@ -778,7 +778,7 @@ mm_cinterion_parse_sxrat_test (const gchar *response,
+         return FALSE;
+     }
+ 
+-    r = g_regex_new ("\\^SXRAT:\\s*\\(([^\\)]*)\\),\\(([^\\)]*)\\)(,\\(([^\\)]*)\\))?(?:\\r\\n)?",
++    r = g_regex_new ("\\^SXRAT:\\s*\\(([^\\)]*)\\),\\s*\\(([^\\)]*)\\)(,\\s*\\(([^\\)]*)\\))?(?:\\r\\n)?",
+                      G_REGEX_DOLLAR_ENDONLY | G_REGEX_RAW,
+                      0, NULL);
+ 
+-- 
+2.43.0
+

--- a/patch/0003-cinterion-add-USB-interface-number-0x05-for-TX62-mod.patch
+++ b/patch/0003-cinterion-add-USB-interface-number-0x05-for-TX62-mod.patch
@@ -1,0 +1,33 @@
+From 49fb75cd945643c3d1f7bededb5e2cc854bc3146 Mon Sep 17 00:00:00 2001
+From: Lorenzo Medici <lorenzo.medici@canonical.com>
+Date: Fri, 20 Mar 2026 16:24:04 +0200
+Subject: [PATCH 1/1] cinterion: add USB interface number 0x05 for TX62 modem
+
+Backports 49fb75cd945643c3d1f7bededb5e2cc854bc3146 merged to upstream
+Author: Lorenzo Medici <lorenzo.medici@canonical.com>
+Date:   Fri Mar 20 16:24:04 2026 +0200
+MR:     https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/1435/commits
+
+Signed-off-by: Lorenzo Medici <lorenzo.medici@canonical.com>
+---
+ src/plugins/cinterion/mm-broadband-bearer-cinterion.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/plugins/cinterion/mm-broadband-bearer-cinterion.c b/src/plugins/cinterion/mm-broadband-bearer-cinterion.c
+index 396837fe..4bd9234f 100644
+--- a/src/plugins/cinterion/mm-broadband-bearer-cinterion.c
++++ b/src/plugins/cinterion/mm-broadband-bearer-cinterion.c
+@@ -60,6 +60,10 @@ static const UsbInterfaceConfig usb_interface_configs[] = {
+         .swwan_index   = 1,
+         .usb_iface_num = 0x08,
+     },
++    {
++        .swwan_index = 1,
++        .usb_iface_num = 0x05,
++    }
+ };
+ 
+ static gint
+-- 
+2.43.0
+


### PR DESCRIPTION
This PR contains two changes that are necessary to make the TX62-W-C modem be compatible with ModemManager:
 - updated regex testing SXRAT backported from `1.24.2`
 - added a new `usb_iface_num` `0x05` that is specific to this modem (or family)

The changes have been verified locally on a Ubuntu 24.04 x86 device and on an Ubuntu Core 24 arm64 device.