### PR TITLE
Change snap grade to stable

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,9 +10,8 @@ description: |
   Please find the source code at
   https://github.com/snapcore/modem-manager-snap/tree/snap-26
 confinement: strict
-grade: devel
+grade: stable
 base: core26
-build-base: devel
 
 slots:
   service: modem-manager


### PR DESCRIPTION
The snap is changed to `grade: stable` ahead of UC26 release.
`build-base: devel` has also been removed, so future builds will have to use snapcraft from `latest/edge/early-core26` branch.

Still outstanding:
  - change the source branch from `ubuntu/resolute-proposed` to `applied/ubuntu/resolute` (needs Launchpad to be updated)
  - uncomment the `check-versions` call in the `override-build` script (needs Launchpad branch and released deb to match)